### PR TITLE
chore(dependabot): align PR title prefixes with Conventional Commits

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -47,7 +47,7 @@ if [ "${branch}" = "master" ] || [ "${branch}" = "main" ]; then
 fi
 
 # 許可する種別（| 区切り）。必要に応じて BRANCH_TYPES で上書き。
-TYPES="${BRANCH_TYPES:-feature|fix|docs|style|refactor|perf|test|build|ci|chore|revert|dependabot}"
+TYPES="${BRANCH_TYPES:-feature|fix|docs|style|refactor|perf|test|build|ci|chore|revert}"
 
 # 形式:
 # <type>/<optional-issue>-<slug>

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,9 @@ updates:
   labels:
     - "dependencies"
     - "ci"
+  commit-message:
+    prefix: "chore(ci)"
+    include: "scope"
 
 # ─────────────────────────────────────────────────────────
 # 2) Node.js (pnpm-lock.yaml) の依存を監視
@@ -38,7 +41,8 @@ updates:
   open-pull-requests-limit: 10
   rebase-strategy: "auto"
   commit-message:
-    prefix: "deps"
+    prefix: "fix"
+    prefix-development: "chore"
     include: "scope"
   groups:
     wrangler-and-workers:


### PR DESCRIPTION
## 📌 概要

<!-- このPRの目的・背景を簡潔に書いてください -->
Dependabot が作成する PR タイトルの prefix を見直し、Conventional Commits の運用に寄せました。

## 🛠 変更内容

<!-- このPRで加えた変更をリストアップしてください -->
- npm 依存更新の PR タイトル prefix を分離
  - dependencies → `fix`
  - devDependencies → `chore`
- GitHub Actions 更新の PR タイトル prefix を `chore(ci)` に統一
- `include: scope` を有効化し、更新対象（package / group）がタイトルから判別できるように変更

## ✅ 確認事項

- [x] Dependabot が作成する PR タイトルの先頭が以下になること
- [x] 既存の groups / ignore 設定に影響がないこと

## 留意点

<!-- このPRを使用するうえで注意すべきことをリストアップしてください。 -->
<!-- 必要がなければ N/A としてください -->
Closes #54